### PR TITLE
feat: deprecate `init()` (use `initValidator()` instead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install @mmyoji/object-validator
 ## Usage
 
 ```ts
-import { init } from "@mmyoji/object-validator";
+import { initValidator } from "@mmyoji/object-validator";
 
 type TargetObject = {
   name: string;
@@ -21,7 +21,7 @@ type TargetObject = {
   isAdmin?: boolean;
 };
 
-const validate = init<TargetObject>({
+const validate = initValidator<TargetObject>({
   name: {
     type: "string",
     required: true,

--- a/lib/core/init.ts
+++ b/lib/core/init.ts
@@ -10,30 +10,6 @@ import { numberValidator } from "./number.validator";
  *
  * @param schema {Schema}
  * @returns {ValidatorFunc}
- *
- * # Example
- *
- * ```ts
- * type ObjectType = {
- *   username: string,
- *   isAdmin?: boolean,
- * }
- *
- * const validate = init<ObjectType>({
- *   username: {
- *     type: "string",
- *     required: true,
- *     minLength: 3,
- *     maxLength: 100,
- *   },
- *   isAdmin: {
- *     type: "boolean",
- *   },
- * });
- *
- * const errors = validate({ username: "ab", isAdmin: true })
- * // [{ key: "username", message: "username is too short. It must be 3 at least." }]
- * ```
  */
 export function init<Args extends object>(schema: Schema): ValidatorFunc<Args> {
   return (obj: Args) => {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,3 +1,7 @@
 import { init } from "./core/init";
 
-export { init };
+export {
+  /** @deprecated use `initValidator` instead */
+  init,
+  init as initValidator,
+};


### PR DESCRIPTION
`init` can conflict other library or app code.